### PR TITLE
Update 02_advanced_stack_usage.ipynb

### DIFF
--- a/notebooks/tutorials/02/02_advanced_stack_usage.ipynb
+++ b/notebooks/tutorials/02/02_advanced_stack_usage.ipynb
@@ -416,7 +416,7 @@
    "source": [
     "We've introduced the **`CAR`** instruction which extract the left part of a pair.  \n",
     "\n",
-    "To extract the right part of the element on top of the stack, you can use **`CDR`**. As for **`CAR`**, the left part of the pair will be removed from the stack and lost:"
+    "To extract the right part of the element on top of the stack, you can use **`CDR`**. As for **`CDR`**, the left part of the pair will be removed from the stack and lost:"
    ]
   },
   {


### PR DESCRIPTION
Fixed type it should be CDR instead of CAR which removes the left part of the PAIR from stack